### PR TITLE
リスト周りのレイアウトを整形。

### DIFF
--- a/lib/define_dice.dart
+++ b/lib/define_dice.dart
@@ -21,40 +21,43 @@ class DefineDice extends StatelessWidget {
           },
         ),
         Container(
+          height: 50,
+          margin: const EdgeInsets.only(top: 10.0),
           child: ListView.builder(
-            // scrollDirection: Axis.horizontal,
-            shrinkWrap: true,
+            scrollDirection: Axis.horizontal,
             itemCount: nkoController.dices.length,
-            itemBuilder: (BuildContext context, int index) {
-              // 初期値
+            itemBuilder: (context, index) {
               textFieldControllers
                   .add(TextEditingController(text: nkoController.dices[index]));
-              return Row(
-                children: <Widget>[
-                  Expanded(
-                    child: TextField(
-                      inputFormatters: [
-                        LengthLimitingTextInputFormatter(1),
-                      ],
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        hintText: "（例）イ",
-                      ),
-                      controller: textFieldControllers[index],
-                      onChanged: (text) {
-                        nkoController.dices[index] = text;
-                      },
-                    ),
+
+              return SizedBox(
+                width: 125,
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: Colors.red),
+                    borderRadius: BorderRadius.circular(10),
                   ),
-                  InkWell(
-                    child: const Icon(Icons.close),
-                    onTap: () {
-                      if (nkoController.dices.isNotEmpty) {
-                        nkoController.removeDiceAt(index);
-                      }
+                  child: TextField(
+                    inputFormatters: [
+                      LengthLimitingTextInputFormatter(1),
+                    ],
+                    decoration: InputDecoration(
+                      suffix: InkWell(
+                        child: const Icon(Icons.close),
+                        onTap: () {
+                          if (nkoController.dices.isNotEmpty) {
+                            nkoController.removeDiceAt(index);
+                          }
+                        },
+                      ),
+                      hintText: "（例）イ",
+                    ),
+                    controller: textFieldControllers[index],
+                    onChanged: (text) {
+                      nkoController.dices[index] = text;
                     },
-                  )
-                ],
+                  ),
+                ),
               );
             },
           ),

--- a/lib/define_dice.dart
+++ b/lib/define_dice.dart
@@ -20,47 +20,48 @@ class DefineDice extends StatelessWidget {
             nkoController.initDice();
           },
         ),
-        Container(
-          height: 50,
-          margin: const EdgeInsets.only(top: 10.0),
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            itemCount: nkoController.dices.length,
-            itemBuilder: (context, index) {
-              textFieldControllers
-                  .add(TextEditingController(text: nkoController.dices[index]));
+        ListView.builder(
+          shrinkWrap: true,
+          itemCount: nkoController.dices.length,
+          itemBuilder: (context, index) {
+            textFieldControllers
+                .add(TextEditingController(text: nkoController.dices[index]));
 
-              return SizedBox(
-                width: 125,
-                child: Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(color: Colors.red),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: TextField(
-                    inputFormatters: [
-                      LengthLimitingTextInputFormatter(1),
-                    ],
-                    decoration: InputDecoration(
-                      suffix: InkWell(
-                        child: const Icon(Icons.close),
-                        onTap: () {
-                          if (nkoController.dices.isNotEmpty) {
-                            nkoController.removeDiceAt(index);
-                          }
-                        },
-                      ),
-                      hintText: "（例）イ",
+            return Row(
+              children: [
+                Text((index + 1).toString() + "面"),
+                Expanded(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.red),
+                      borderRadius: BorderRadius.circular(5),
                     ),
-                    controller: textFieldControllers[index],
-                    onChanged: (text) {
-                      nkoController.dices[index] = text;
-                    },
+                    child: TextField(
+                      inputFormatters: [
+                        LengthLimitingTextInputFormatter(1),
+                      ],
+                      decoration: InputDecoration(
+                        suffix: InkWell(
+                          child: const Icon(Icons.close, size: 20),
+                          onTap: () {
+                            if (nkoController.dices.isNotEmpty) {
+                              nkoController.removeDiceAt(index);
+                            }
+                          },
+                        ),
+                        hintText: "（例）イ",
+                      ),
+                      controller: textFieldControllers[index],
+                      onChanged: (text) {
+                        nkoController.dices[index] = text;
+                      },
+                    ),
                   ),
                 ),
-              );
-            },
-          ),
+              ],
+            );
+          },
         ),
         Row(
           children: [

--- a/lib/define_keywords.dart
+++ b/lib/define_keywords.dart
@@ -24,9 +24,17 @@ class DefineKeywords extends StatelessWidget {
               children: <Widget>[
                 Expanded(
                   child: TextField(
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       border: OutlineInputBorder(),
                       hintText: "（例）イタリア",
+                      suffix: InkWell(
+                        child: const Icon(Icons.close, size: 20),
+                        onTap: () {
+                          if (nkoController.keywords.isNotEmpty) {
+                            nkoController.removeKeywordAt(index);
+                          }
+                        },
+                      ),
                     ),
                     controller: textFieldControllers[index],
                     onChanged: (text) {
@@ -34,14 +42,6 @@ class DefineKeywords extends StatelessWidget {
                     },
                   ),
                 ),
-                InkWell(
-                  child: const Icon(Icons.close),
-                  onTap: () {
-                    if (nkoController.keywords.isNotEmpty) {
-                      nkoController.removeKeywordAt(index);
-                    }
-                  },
-                )
               ],
             );
           },

--- a/lib/ogehindice.dart
+++ b/lib/ogehindice.dart
@@ -19,18 +19,13 @@ class PlayJohindice extends StatelessWidget {
             nkoController.generateDice();
           },
         ),
-        ListView.builder(
-          shrinkWrap: true,
-          itemCount: nkoController.gotDices.length,
-          itemBuilder: (BuildContext context, int index) {
-            return Row(
-              children: <Widget>[
-                Expanded(
-                  child: Text(nkoController.gotDices[index]),
-                ),
-              ],
-            );
-          },
+        Row(
+          children: <Widget>[
+            for (int i = 0; i < nkoController.gotDices.length; i++)
+              Expanded(
+                child: Text(nkoController.gotDices[i]),
+              ),
+          ],
         ),
         ListView.builder(
           shrinkWrap: true,

--- a/web/index.html
+++ b/web/index.html
@@ -15,7 +15,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="/">
+  <base href="/johinkodice/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
@@ -30,7 +30,7 @@
   <!-- Favicon -->
   <link rel=”icon” type=”image/png” href=“favicon.png”>
 
-  <title>Let's JOHINKODICE</title>
+  <title>JOHINKODICE</title>
   <link rel="manifest" href="manifest.json">
 </head>
 


### PR DESCRIPTION
- サイコロ定義用リストを水平表示
    - 画面幅を超えたときは折返し
- 要素削除用バツアイコンをテキストボックス内に表示